### PR TITLE
breaking: remove default node-fetch dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
   },
   "dependencies": {
     "json-stable-stringify": "^1.0.1",
-    "node-fetch": "^2.6.1",
     "protobufjs-old-fixed-webpack": "3.8.5"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,6 @@ import BridgeTransportV2 from './bridge/v2';
 import LowlevelTransportWithSharedConnections from './lowlevel/withSharedConnections';
 import FallbackTransport from './fallback';
 import WebUsbPlugin from './lowlevel/webusb';
-import fetch from 'node-fetch'
-
-BridgeTransportV2.setFetch(fetch, true);
 
 export default {
   BridgeV2: BridgeTransportV2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1753,11 +1753,6 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-node-fetch@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
-
 node-pre-gyp@^0.6.39:
   version "0.6.39"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz#c00e96860b23c0e1420ac7befc5044e1d78d8649"


### PR DESCRIPTION
This breaks this package in Node.js by default, but removes `node-fetch` dependency completely.

It's now the consumer responsibility to call `BridgeV2.setFetch(require('node-fetch'), true)` when running on Node.js.