### PR TITLE
fix: monkey patch (turn hex strings into buffers)

### DIFF
--- a/src/bridge/v2.js
+++ b/src/bridge/v2.js
@@ -6,6 +6,9 @@
 
 'use strict';
 
+import {patch} from './protobuf/monkey_patch';
+patch();
+
 // import semvercmp from 'semver-compare';
 import {request as http, setFetch as rSetFetch} from './http';
 import type {AcquireInput, TrezorDeviceInfoWithSession, MessageFromTrezor} from '../transport';

--- a/src/lowlevel/protobuf/monkey_patch.js
+++ b/src/lowlevel/protobuf/monkey_patch.js
@@ -1,0 +1,31 @@
+/* @flow */
+"use strict";
+
+import * as ProtoBuf from "protobufjs-old-fixed-webpack";
+const ByteBuffer = ProtoBuf.ByteBuffer;
+
+let patched = false;
+
+// monkey-patching ProtoBuf,
+// so that bytes are loaded and decoded from hexadecimal
+// when we expect bytes and we get string
+export function patch(): void {
+  if (!patched) {
+    ProtoBuf.Reflect.Message.Field.prototype.verifyValueOriginal = ProtoBuf.Reflect.Message.Field.prototype.verifyValue;
+
+    // note: don't rewrite this function to arrow (value, skipRepeated) => ....
+    // since I need `this` from the original context
+    ProtoBuf.Reflect.Message.Field.prototype.verifyValue = function (value, skipRepeated) {
+      let newValue = value;
+      if (this.type === ProtoBuf.TYPES[`bytes`]) {
+        if (value != null) {
+          if (typeof value === `string`) {
+            newValue = ByteBuffer.wrap(value, `hex`);
+          }
+        }
+      }
+      return this.verifyValueOriginal(newValue, skipRepeated);
+    };
+  }
+  patched = true;
+}


### PR DESCRIPTION
The monkey patch was removed, this turns hex strings into byte buffers by patching the prototype of protobuf which is heavily relied upon by trezor-events.