### PR TITLE
fix: receive message type buffer

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "check": "make check"
   },
   "engines": {
-    "node": "16.13.0",
-    "yarn": ">=1.19.1 <1.22.0"
+    "node": "16.13.x",
+    "yarn": ">=1.19.1 <1.22.19"
   },
   "repository": "https://github.com/trezor/trezor-link.git",
   "author": "Karel Bílek <kb@karelbilek.com>",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "check": "make check"
   },
   "engines": {
-    "node": ">8.0.0"
+    "node": "16.13.0",
+    "yarn": ">=1.19.1 <1.22.0"
   },
   "repository": "https://github.com/trezor/trezor-link.git",
   "author": "Karel Bílek <kb@karelbilek.com>",

--- a/src/bridge/v2.js
+++ b/src/bridge/v2.js
@@ -6,7 +6,7 @@
 
 'use strict';
 
-import {patch} from './protobuf/monkey_patch';
+import {patch} from './../lowlevel/protobuf/monkey_patch';
 patch();
 
 // import semvercmp from 'semver-compare';

--- a/src/bridge/v2.js
+++ b/src/bridge/v2.js
@@ -85,11 +85,11 @@ export default class BridgeTransport {
   }
 
   @debugInOut
-  async getVersion (): Promise<string> {
+  async getVersion(): Promise<string> {
     // $FlowIssue
-    const { version } = await this._post({ url: '/' })
-    this.version = version
-    return version
+    const { version } = await this._post({ url: `/` });
+    this.version = version;
+    return version;
   }
 
   @debugInOut

--- a/src/lowlevel/protobuf/message_decoder.js
+++ b/src/lowlevel/protobuf/message_decoder.js
@@ -70,11 +70,9 @@ function messageToJSON(message: ProtoBuf.Builder.Message) : Object {
   const res = {};
   const meta = message.$type;
 
-  if (!meta) {
-    if (message instanceof ByteBuffer) {
-      const hex = message.toHex();
-      return hex;
-    }
+  if (message instanceof ByteBuffer) {
+    const hex = message.toHex();
+    return hex;
   }
 
   for (const key in message) {

--- a/src/lowlevel/protobuf/message_decoder.js
+++ b/src/lowlevel/protobuf/message_decoder.js
@@ -70,6 +70,13 @@ function messageToJSON(message: ProtoBuf.Builder.Message) : Object {
   const res = {};
   const meta = message.$type;
 
+  if (!meta) {
+    if (message.buffer && Buffer.isBuffer(message.buffer)) {
+      const hex = message.toHex();
+      return hex;
+    }
+  }
+
   for (const key in message) {
     const value = message[key];
     if (typeof value === `function`) {

--- a/src/lowlevel/protobuf/message_decoder.js
+++ b/src/lowlevel/protobuf/message_decoder.js
@@ -71,7 +71,7 @@ function messageToJSON(message: ProtoBuf.Builder.Message) : Object {
   const meta = message.$type;
 
   if (!meta) {
-    if (message.buffer && Buffer.isBuffer(message.buffer)) {
+    if (message instanceof ByteBuffer) {
       const hex = message.toHex();
       return hex;
     }

--- a/src/lowlevel/protobuf/message_decoder.js
+++ b/src/lowlevel/protobuf/message_decoder.js
@@ -9,7 +9,7 @@ import * as ProtoBuf from "protobufjs-old-fixed-webpack";
 const ByteBuffer = ProtoBuf.ByteBuffer;
 const Long = ProtoBuf.Long;
 
-import {Messages} from "./messages.js";
+import { Messages } from "./messages.js";
 
 class MessageInfo {
   messageConstructor: ProtoBuf.Builder.Message;
@@ -36,7 +36,7 @@ export class MessageDecoder {
 
   // Returns an info about this message,
   // which includes the constructor object and a name
-  _messageInfo() : MessageInfo {
+  _messageInfo(): MessageInfo {
     const r = this.messages.messagesByType[this.type];
     if (r == null) {
       throw new Error(`Method type not found - ${this.type}`);
@@ -45,19 +45,19 @@ export class MessageDecoder {
   }
 
   // Returns the name of the message
-  messageName() : string {
+  messageName(): string {
     return this._messageInfo().name;
   }
 
   // Returns the actual decoded message, as a ProtoBuf.js object
-  _decodedMessage() : ProtoBuf.Builder.Message {
+  _decodedMessage(): ProtoBuf.Builder.Message {
     const constructor = this._messageInfo().messageConstructor;
     return constructor.decode(this.data);
   }
 
   // Returns the message decoded to JSON, that could be handed back
   // to trezor.js
-  decodedJSON() : Object {
+  decodedJSON(): Object {
     const decoded = this._decodedMessage();
     const converted = messageToJSON(decoded);
 
@@ -66,14 +66,9 @@ export class MessageDecoder {
 }
 
 // Converts any ProtoBuf message to JSON in Trezor.js-friendly format
-function messageToJSON(message: ProtoBuf.Builder.Message) : Object {
+function messageToJSON(message: ProtoBuf.Builder.Message): Object {
   const res = {};
   const meta = message.$type;
-
-  if (message instanceof ByteBuffer) {
-    const hex = message.toHex();
-    return hex;
-  }
 
   for (const key in message) {
     const value = message[key];
@@ -86,8 +81,10 @@ function messageToJSON(message: ProtoBuf.Builder.Message) : Object {
       const num = value.toNumber();
       res[key] = num;
     } else if (Array.isArray(value)) {
-      const decodedArr = value.map((i) => {
-        if (typeof i === `object`) {
+      const decodedArr = value.map(i => {
+        if (i instanceof ByteBuffer) {
+          return i.toHex();
+        } else if (typeof i === "object") {
           return messageToJSON(i);
         } else {
           return i;


### PR DESCRIPTION
# Summary
When developing XMR signing, I received a decoded message with has BytesBuffer type and it caused the below issue.  
<img width="1212" alt="Screenshot 2022-05-22 at 02 26 10" src="https://user-images.githubusercontent.com/11265773/169666432-ba2e75c8-cc15-4c1f-933e-db659cd6314e.png">

The decoded message is:
```
ByteBuffer {
      buffer: <Buffer 0a 20 1c d1 5f fd 1e db 01 bd 56 22 a8 b6 b2 7f d9 04 1f b3 a7 82 54 59 99 a8 94 89 b0 5a 29 e3 48 34 0a 20 9d 22 8b 71 79 14 4d f2 6a d3 18 d0 09 f8 ... 22 more bytes>,
      offset: 2,
      markedOffset: -1,
      limit: 34,
      littleEndian: true,
      noAssert: false
    }
```
We cannot handle this kind of message in the current way by looping through all keys of this message and checking type.

Parent PR: [#4](https://github.com/ExodusMovement/trezor-link/pull/4)

# How to test
- Build the current source with this change.
- Attach your local `trezor-link` to [trezor-events](https://github.com/ExodusMovement/trezor-events/tree/andyvo/monero-signing) repository like this:
<img width="420" alt="Screenshot 2022-05-22 at 02 32 40" src="https://user-images.githubusercontent.com/11265773/169666596-286d62cf-eb24-489a-9f79-ede83fc8dbc0.png">
- Run yarn test
