### PR TITLE
fix: loosen engines.node

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check": "make check"
   },
   "engines": {
-    "node": "16.13.x",
+    "node": ">=16.13.0",
     "yarn": ">=1.19.1 <1.22.19"
   },
   "repository": "https://github.com/ExodusMovement/trezor-link.git",


### PR DESCRIPTION
https://github.com/ExodusMovement/trezor-link/pull/5 unnecessarily tightened the requested Node version to a specific MAJOR.MINOR version; this loosens it to `>=`, as we don't know of bugs in any later versions of Node.