### PR TITLE
fix: add prepare script to ensure files are built before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "make build",
-    "check": "make check"
+    "check": "make check",
+    "prepare": "npm run build"
   },
   "engines": {
     "node": ">=16.13.0",


### PR DESCRIPTION
I published v1.8.3, only to discover I hadn't built first. This fixes that problem.